### PR TITLE
Show exact dates in student views

### DIFF
--- a/devilry/devilry_student/cradmin_student/recentdeliveriesapp.py
+++ b/devilry/devilry_student/cradmin_student/recentdeliveriesapp.py
@@ -4,7 +4,7 @@ from django_cradmin import crapp
 
 from devilry.apps.core.models import deliverytypes
 from devilry.apps.core.models import Delivery
-from devilry.devilry_student.cradminextensions.columntypes import DeliverySummaryColumn, NaturaltimeColumn
+from devilry.devilry_student.cradminextensions.columntypes import DeliverySummaryColumn, NaturaltimeAndDateTimeColumn
 
 
 class DeliverySummaryWithAssignmentColumn(DeliverySummaryColumn):
@@ -12,7 +12,7 @@ class DeliverySummaryWithAssignmentColumn(DeliverySummaryColumn):
         'delivery-summary-with-assignment-column.django.html'
 
 
-class TimeOfDeliveryColumn(NaturaltimeColumn):
+class TimeOfDeliveryColumn(NaturaltimeAndDateTimeColumn):
     modelfield = 'time_of_delivery'
     allcells_css_classes = ['hidden-xs']
     # column_width = '270px'

--- a/devilry/devilry_student/cradmin_student/recentfeedbacksapp.py
+++ b/devilry/devilry_student/cradmin_student/recentfeedbacksapp.py
@@ -4,14 +4,14 @@ from django.conf import settings
 from django_cradmin import crapp
 
 from devilry.apps.core.models import Delivery
-from devilry.devilry_student.cradminextensions.columntypes import NaturaltimeColumn
+from devilry.devilry_student.cradminextensions.columntypes import NaturaltimeAndDateTimeColumn
 
 from .recentdeliveriesapp import DeliverySummaryWithAssignmentColumn
 from .recentdeliveriesapp import PeriodInfoColumn
 from .recentdeliveriesapp import PeriodInfoXsColumn
 
 
-class FeedbackSaveTimestampColumn(NaturaltimeColumn):
+class FeedbackSaveTimestampColumn(NaturaltimeAndDateTimeColumn):
     modelfield = 'save_timestamp'
     allcells_css_classes = ['hidden-xs']
     # orderingfield = 'last_feedback__save_timestamp'

--- a/devilry/devilry_student/templates/devilry_student/cradmin_student/waitingfordeliveriesapp/last-deadline.django.html
+++ b/devilry/devilry_student/templates/devilry_student/cradmin_student/waitingfordeliveriesapp/last-deadline.django.html
@@ -1,7 +1,9 @@
 {% load humanize %}
+<div class="devilry-student-last-deadline">
 {% if in_the_future %}
-    <strong class="text-success">{{ deadline_datetime|naturaltime }}</strong>
+    <p><strong class="text-success">{{ deadline_datetime|naturaltime }}</strong></p>
 {% else %}
-    <strong class="text-warning">{{ deadline_datetime|naturaltime }}</strong>
+    <p><strong class="text-warning">{{ deadline_datetime|naturaltime }}</strong></p>
 {% endif %}
-{#<small class="text-muted">({{ deadline_datetime|date:"SHORT_DATETIME_FORMAT" }})</small>#}
+    <p>{{ deadline_datetime|date:"SHORT_DATETIME_FORMAT" }}</p>
+</div>

--- a/devilry/devilry_student/templates/devilry_student/cradminextensions/columntypes/naturaltime-and-datetime-column.django.html
+++ b/devilry/devilry_student/templates/devilry_student/cradminextensions/columntypes/naturaltime-and-datetime-column.django.html
@@ -1,3 +1,5 @@
 {% load humanize %}
-{{ datetimeobject|naturaltime }}
-<small class="text-muted">({{ datetimeobject|date:datetime_format }})</small>
+<div class="devilry-student-naturaltime-and-datetime-column">
+    <p>{{ datetimeobject|naturaltime }}</p>
+    <p>{{ datetimeobject|date:datetime_format }}</p>
+</div>

--- a/devilry/devilry_student/tests/cradmin_student/test_recentdeliveriesapp.py
+++ b/devilry/devilry_student/tests/cradmin_student/test_recentdeliveriesapp.py
@@ -1,5 +1,6 @@
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.test import TestCase
+from django.utils.formats import date_format
 from django_cradmin.crinstance import reverse_cradmin_url
 import htmls
 from django_cradmin import crinstance
@@ -71,7 +72,9 @@ class TestRecentDeliveries(TestCase):
             'atestcourse - testperiod')
         self.assertEquals(
             selector.one('#objecttableview-table tbody tr td:nth-child(4)').alltext_normalized,
-            htmls.normalize_whitespace(naturaltime(deliverybuilder.delivery.time_of_delivery)))
+            htmls.normalize_whitespace(
+                naturaltime(deliverybuilder.delivery.time_of_delivery)
+                + date_format(deliverybuilder.delivery.time_of_delivery, "SHORT_DATETIME_FORMAT")))
 
     def test_render_no_feedback(self):
         AssignmentGroupBuilder.quickadd_ducku_duck1010_active_assignment1_group(self.testuser)\

--- a/devilry/devilry_student/tests/cradmin_student/test_recentfeedbacksapp.py
+++ b/devilry/devilry_student/tests/cradmin_student/test_recentfeedbacksapp.py
@@ -1,5 +1,6 @@
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.test import TestCase
+from django.utils.formats import date_format
 from django_cradmin.crinstance import reverse_cradmin_url
 import htmls
 from django_cradmin import crinstance
@@ -71,7 +72,8 @@ class TestRecentFeedbacks(TestCase):
             'atestcourse - testperiod')
         self.assertEquals(
             selector.one('#objecttableview-table tbody tr td:nth-child(4)').alltext_normalized,
-            htmls.normalize_whitespace(naturaltime(feedback.save_timestamp)))
+            htmls.normalize_whitespace(naturaltime(feedback.save_timestamp)
+                                       + date_format(feedback.save_timestamp, "SHORT_DATETIME_FORMAT")))
 
     def test_render_feedback_passed(self):
         AssignmentGroupBuilder.quickadd_ducku_duck1010_active_assignment1_group(self.testuser)\

--- a/devilry/devilry_student/tests/cradmin_student/test_waitingfordeliveriesapp.py
+++ b/devilry/devilry_student/tests/cradmin_student/test_waitingfordeliveriesapp.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.utils.formats import date_format
 from django_cradmin.crinstance import reverse_cradmin_url
 import htmls
 
@@ -50,7 +51,7 @@ class TestWaitingForDeliveries(TestCase):
             selector.one('#objecttableview-table tbody tr td:nth-child(3)').alltext_normalized,
             'atestcourse - testperiod')
         self.assertEquals(
-            selector.one('#objecttableview-table tbody tr td:nth-child(4)').alltext_normalized,
+            selector.one('#objecttableview-table tbody tr td:nth-child(4) .text-success').alltext_normalized,
             u'6 days, 23 hours from now')
         self.assertTrue(selector.exists('#objecttableview-table tbody tr td:nth-child(4) .text-success'))
 
@@ -115,5 +116,5 @@ class TestWaitingForDeliveries(TestCase):
         self.assertTrue(
             selector.exists('#objecttableview-table tbody tr td:nth-child(4) .text-warning'))
         self.assertEquals(
-            selector.one('#objecttableview-table tbody tr td:nth-child(4)').alltext_normalized,
+            selector.one('#objecttableview-table tbody tr td:nth-child(4) .text-warning').alltext_normalized,
             u'1 week ago')

--- a/devilry/devilry_theme2/static/devilry_theme2/css/styles.css
+++ b/devilry/devilry_theme2/static/devilry_theme2/css/styles.css
@@ -9998,6 +9998,19 @@ ul.list-inline.list-inline-commaseparated li:last-child:after {
 .devilry-student-delivery-summarycolumn p.devilry-student-delivery-summarycolumn-no-feedback {
   color: #777777;
 }
+.devilry-student-naturaltime-and-datetime-column p,
+.devilry-student-last-deadline p {
+  margin: 0;
+}
+.devilry-student-naturaltime-and-datetime-column p:first-child,
+.devilry-student-last-deadline p:first-child {
+  margin-bottom: 5px;
+}
+.devilry-student-naturaltime-and-datetime-column p:last-child,
+.devilry-student-last-deadline p:last-child {
+  font-size: 14px;
+  color: #777777;
+}
 #devilry_search_view form .form-group {
   margin-bottom: 0;
 }

--- a/devilry/devilry_theme2/static/devilry_theme2/less/devilry_student/columntypes.less
+++ b/devilry/devilry_theme2/static/devilry_theme2/less/devilry_student/columntypes.less
@@ -17,3 +17,19 @@
     color: @text-muted;
   }
 }
+
+.devilry-student-naturaltime-and-datetime-column,
+    .devilry-student-last-deadline {
+  p {
+    margin: 0;
+  }
+
+  p:first-child {
+    margin-bottom: 5px;
+  }
+
+  p:last-child {
+    font-size: @font-size-small;
+    color: @text-muted;
+  }
+}


### PR DESCRIPTION
Add exact dates in smaller, muted font to the lists in student list views.

![screen shot 2015-05-28 at 21 54 51 1](https://cloud.githubusercontent.com/assets/4187449/7869631/43df9b76-0584-11e5-86b6-db6db6921ed7.png)

Ref #746 (partial fix)
