### PR TITLE
Developer docs add libpq-dev for Ubuntu

### DIFF
--- a/not_for_deploy/docs/developer/gettingstarted.rst
+++ b/not_for_deploy/docs/developer/gettingstarted.rst
@@ -73,7 +73,7 @@ Ubuntu Linux
 ============
 ::
 
-    $ sudo apt-get install build-essential python-dev python-virtualenv libncurses5-dev virtualenvwrapper libxslt1-dev libxml2 libxml2-dev zlib1g-dev
+    $ sudo apt-get install build-essential python-dev python-virtualenv libncurses5-dev virtualenvwrapper libxslt1-dev libxml2 libxml2-dev zlib1g-dev libpq-dev
 
 
 


### PR DESCRIPTION
The libpq-dev package provides pg_config to fix the `Error: pg_config executable not found.` when installing psycopg2 via pip.